### PR TITLE
convolution from layers replaced

### DIFF
--- a/athenet/layers/conv.py
+++ b/athenet/layers/conv.py
@@ -6,7 +6,7 @@ import theano
 import theano.tensor as T
 
 from athenet.layers import WeightedLayer
-from athenet.utils import cudnn_available
+from athenet.utils.misc import convolution
 
 
 class ConvolutionalLayer(WeightedLayer):
@@ -108,39 +108,10 @@ class ConvolutionalLayer(WeightedLayer):
         return extra_pixels
 
     def _get_output(self, layer_input):
-        n_channels = self.image_shape[2]
-        n_filters = self.filter_shape[2]
-
-        n_group_channels = n_channels / self.n_groups
-        n_group_filters = n_filters / self.n_groups
-
         # By default, Theano doesn't use cuDNN convolutions if
         # subsample != (1, 1), so we need to call it manually
-        if cudnn_available():  # use cuDNN convolutions
-            conv_outputs = [theano.sandbox.cuda.dnn.dnn_conv(
-                img=self.input[:, i*n_group_channels:(i+1)*n_group_channels,
-                               :, :],
-                kerns=self.W_shared[i*n_group_filters:(i+1)*n_group_filters,
-                                    :, :, :],
-                subsample=self.stride
-            ) for i in xrange(self.n_groups)]
-        else:  # let Theano decide which implementation to use
-            h, w = self.image_shape[0:2]
-            pad_h, pad_w = self.padding
-            group_image_shape = (self.batch_size, n_group_channels,
-                                 h + 2*pad_h, w + 2*pad_w)
-            h, w = self.filter_shape[0:2]
-            group_filter_shape = (n_group_filters, n_group_channels, h, w)
-
-            conv_outputs = [theano.tensor.nnet.conv.conv2d(
-                input=self.input[:, i*n_group_channels:(i+1)*n_group_channels,
-                                 :, :],
-                filters=self.W_shared[i*n_group_filters:(i+1)*n_group_filters,
-                                      :, :, :],
-                filter_shape=group_filter_shape,
-                image_shape=group_image_shape,
-                subsample=self.stride
-            ) for i in xrange(self.n_groups)]
-
-        conv_output = T.concatenate(conv_outputs, axis=1)
+        conv_output = convolution(self.input, self.W_shared, self.stride,
+                                  self.n_groups, self.image_shape,
+                                  self.padding, self.batch_size,
+                                  self.filter_shape)
         return conv_output + self.b_shared.dimshuffle('x', 0, 'x', 'x')

--- a/athenet/utils/misc.py
+++ b/athenet/utils/misc.py
@@ -8,6 +8,8 @@ import urllib
 import numpy
 
 import theano
+import theano.tensor as T
+import theano.sandbox.cuda
 
 from athenet.utils import BIN_DIR, DATA_DIR
 
@@ -15,7 +17,7 @@ from athenet.utils import BIN_DIR, DATA_DIR
 def load_data_from_pickle(filename):
     """Load data from pickle file.
 
-    :filename: File with pickled data, may be gzipped.
+    :param filename: File with pickled data, may be gzipped.
     :return: Data loaded from file.
     """
     try:
@@ -31,8 +33,8 @@ def load_data_from_pickle(filename):
 def save_data_to_pickle(data, filename):
     """Saves data to gzipped pickle file.
 
-    :data: Data to be saved.
-    :filename: Name of file to save data.
+    :param data: Data to be saved.
+    :param filename: Name of file to save data.
     """
     with gzip.open(filename, 'wb') as f:
         pickle.dump(data, f)
@@ -41,8 +43,8 @@ def save_data_to_pickle(data, filename):
 def load_data(filename, url=None):
     """Load data from file, download file if it doesn't exist.
 
-    :filename: File with pickled data, may be gzipped.
-    :url: Url for downloading file.
+    :param filename: File with pickled data, may be gzipped.
+    :param url: Url for downloading file.
     :return: Unpickled data.
     """
     if not os.path.isfile(filename):
@@ -57,8 +59,8 @@ def load_data(filename, url=None):
 def download_file(filename, url):
     """Download file from given url.
 
-    :filename: Name of a file to be downloaded.
-    :url: Url for downloading file.
+    :param filename: Name of a file to be downloaded.
+    :param url: Url for downloading file.
     """
     directory = os.path.dirname(filename)
     if not os.path.exists(directory):
@@ -72,7 +74,7 @@ def download_file(filename, url):
 def get_data_path(name):
     """Return absolute path to the data file.
 
-    :name: Name of the file.
+    :param name: Name of the file.
     :return: Full path to the file.
     """
     return os.path.join(DATA_DIR, name)
@@ -81,7 +83,7 @@ def get_data_path(name):
 def get_bin_path(name):
     """Return absolute path to the binary data file.
 
-    :name: Name of the file.
+    :param name: Name of the file.
     :return: Full path to the file.
     """
     return os.path.join(BIN_DIR, name)
@@ -92,7 +94,7 @@ def zero_fraction(network):
 
     Biases are not considered.
 
-    :network: Network for which we count fraction of zeros.
+    :param network: Network for which we count fraction of zeros.
     :return: Fraction of zeros.
     """
     params = [layer.W for layer in network.weighted_layers]
@@ -115,8 +117,8 @@ def overwrite(text='', length=None):
     it to work properly. Otherwise optional argument length can be given to
     specify length of a previous text.
 
-    :text: Text to be written.
-    :length: Length of a previous text.
+    :param string text: Text to be written.
+    :param integer length: Length of a previous text.
     """
     global len_prev
     if length is None:
@@ -135,3 +137,38 @@ def cudnn_available():
         return theano.sandbox.cuda.dnn_available()
     except:
         return False
+
+
+def convolution(layer_input, w_shared, stride, n_groups, image_shape,
+                padding, batch_size, filter_shape):
+    n_channels = image_shape[2]
+    n_filters = filter_shape[2]
+
+    n_group_channels = n_channels / n_groups
+    n_group_filters = n_filters / n_groups
+    if cudnn_available():  # use cuDNN convolutions
+        conv_outputs = [theano.sandbox.cuda.dnn.dnn_conv(
+            img=layer_input[:, i*n_group_channels:(i+1)*n_group_channels,
+                            :, :],
+            kerns=w_shared[i*n_group_filters:(i+1)*n_group_filters,
+                           :, :, :],
+            subsample=stride
+        ) for i in xrange(n_groups)]
+    else:  # let Theano decide which implementation to use
+        h, w = image_shape[0:2]
+        pad_h, pad_w = padding
+        group_image_shape = (batch_size, n_group_channels,
+                             h + 2*pad_h, w + 2*pad_w)
+        h, w = filter_shape[0:2]
+        group_filter_shape = (n_group_filters, n_group_channels, h, w)
+
+        conv_outputs = [T.nnet.conv.conv2d(
+            input=layer_input[:, i*n_group_channels:(i+1)*n_group_channels,
+                              :, :],
+            filters=w_shared[i*n_group_filters:(i+1)*n_group_filters,
+                             :, :, :],
+            filter_shape=group_filter_shape,
+            image_shape=group_image_shape,
+            subsample=stride
+        ) for i in xrange(n_groups)]
+    return T.concatenate(conv_outputs, axis=1)


### PR DESCRIPTION
Just replaced convolution from athenet/layers/conv.py:_get_output to athenet/utils/misc.py:convolution. Will be used more than one time.